### PR TITLE
Prevent index out of range error

### DIFF
--- a/uploader.go
+++ b/uploader.go
@@ -52,6 +52,11 @@ func NewCloudwatchUploader(adapter *CloudwatchAdapter) *CloudwatchUploader {
 // while keeping track of the unique sequence token for each log stream.
 func (u *CloudwatchUploader) Start() {
 	for batch := range u.Input {
+		msgLen := len(batch.Msgs)
+		if msgLen == 0 {
+			u.log("The batch input does not have any messaged")
+			continue
+		}
 		msg := batch.Msgs[0]
 		u.log("Submitting batch for %s-%s (length %d, size %v)",
 			msg.Group, msg.Stream, len(batch.Msgs), batch.Size)

--- a/uploader.go
+++ b/uploader.go
@@ -54,7 +54,7 @@ func (u *CloudwatchUploader) Start() {
 	for batch := range u.Input {
 		msgLen := len(batch.Msgs)
 		if msgLen == 0 {
-			u.log("The batch input does not have any messaged")
+			u.log("The batch input does not have any messages")
 			continue
 		}
 		msg := batch.Msgs[0]


### PR DESCRIPTION
Preventing the following error from occuring:

panic: runtime error: index out of range [0] with length 0
goroutine 25 [running]:
github.com/mdsol/logspout-cloudwatch.(*CloudwatchUploader).Start(0xc0002201e0)
	/go/pkg/mod/github.com/mdsol/logspout-cloudwatch@v0.0.0-20190808172654-fa0130853c7d/uploader.go:55 +0xde7
created by github.com/mdsol/logspout-cloudwatch.NewCloudwatchUploader
	/go/pkg/mod/github.com/mdsol/logspout-cloudwatch@v0.0.0-20190808172654-fa0130853c7d/uploader.go:47 +0x23f